### PR TITLE
fix: remove model: sonnet from apple-craft skills to avoid rate limit regression

### DIFF
--- a/plugins/apple-craft/skills/apple-craft-harness/SKILL.md
+++ b/plugins/apple-craft/skills/apple-craft-harness/SKILL.md
@@ -2,7 +2,6 @@
 name: apple-craft-harness
 description: apple-craft 하네스 모드 — Plan→Build→Evaluate 에이전트 루프로 장기 개발 작업 자동화. Anthropic V2 간소화 패턴 기반. "처음부터", "전체", "기능 개발", "feature development", "앱 만들어", "프로젝트 생성", "리팩토링", "대규모 변경", "harness", "하네스", "처음부터 만들어", "전체 구현", "새 앱", "new app", "full implementation", "from scratch" 요청 시 활성화
 argument-hint: "[feature description or project idea]"
-model: sonnet
 allowed-tools:
   - Agent
   - Read

--- a/plugins/apple-craft/skills/apple-craft/SKILL.md
+++ b/plugins/apple-craft/skills/apple-craft/SKILL.md
@@ -2,7 +2,6 @@
 name: apple-craft
 description: Apple 플랫폼 최신 API 통합 개발 가이드 (Xcode 26 기준). Liquid Glass, FoundationModels, Swift 6.2, SwiftData, AlarmKit, Visual Intelligence, WebKit SwiftUI, StoreKit, 3D Charts, MapKit GeoToolbox, AppIntents, Toolbar, Styled Text, Assistive Access, visionOS Widget 등 20개 주제. "Liquid Glass", "리퀴드 글라스", "유리 효과", "glassEffect", "FoundationModels", "온디바이스 LLM", "Apple Intelligence", "Swift Concurrency", "동시성", "async/await", "InlineArray", "Span", "SwiftData 상속", "class inheritance", "Visual Intelligence", "비주얼 인텔리전스", "AlarmKit", "알람", "WebKit", "웹뷰", "WebView", "StoreKit", "인앱 결제", "3D Charts", "3D 차트", "Swift Charts", "MapKit", "GeoToolbox", "PlaceDescriptor", "지도", "AppIntents", "앱 인텐트", "단축어", "Shortcuts", "AttributedString", "속성 문자열", "Toolbar", "툴바", "Styled Text", "TextEditor", "Assistive Access", "접근성", "보조 접근", "visionOS Widget", "위젯", "Apple 개발", "iOS 26", "macOS 26", "watchOS", "tvOS", "visionOS", "WWDC", "최신 API", "새 프레임워크", "apple craft", "apple-craft" 요청 시 활성화
 argument-hint: "[topic or question]"
-model: sonnet
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
Claude Code v2.1.76+ has a regression (issue #34912) where `model: sonnet`
in skill frontmatter incorrectly triggers "long context" rate limits regardless
of actual token usage. Remove the field from both apple-craft and
apple-craft-harness skills so the session's default model is used instead.

https://claude.ai/code/session_01UbM5fBvjXNhd8BcBuMLDAz