### PR TITLE
chore: bump apple-craft 1.2.0, marketplace 1.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "oozoofrog-plugins",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "oozoofrog의 개인 Claude Code 플러그인 마켓플레이스 — macOS 릴리스 자동화, 컨텍스트 아키텍처, GPT 리서치, Codex CLI 위임, Apple 최신 API 개발 가이드",
   "owner": {
     "name": "oozoofrog",
@@ -51,7 +51,7 @@
     {
       "name": "apple-craft",
       "description": "Apple 플랫폼 최신 API 통합 개발 가이드 (Xcode 26) — 20개 주제 + Plan→Build→Evaluate 하네스 에이전트 루프",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "oozoofrog"
       },

--- a/plugins/apple-craft/.claude-plugin/plugin.json
+++ b/plugins/apple-craft/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "apple-craft",
   "description": "Apple 플랫폼 최신 API 통합 개발 가이드 (Xcode 26) — Liquid Glass, FoundationModels, Swift 6.2 등 20개 주제 + Plan→Build→Evaluate 하네스",
   "author": { "name": "oozoofrog" },
-  "version": "1.1.0"
+  "version": "1.2.0"
 }


### PR DESCRIPTION
## Summary

- **apple-craft** 1.1.0 → 1.2.0
- **marketplace** 1.7.0 → 1.8.0

v1.2.0 변경 사항:
- `model: sonnet` 제거 (rate limit 회귀 버그 회피)
- `allowed-tools`에 12개 `mcp__xcode__*` 도구 추가
- SKILL.md 경량화 (532→215줄, progressive disclosure)
- 한국어 트리거 키워드 확대 (730자)
- `preflight.sh` bash 호환성 수정

## Test plan

- [ ] `plugin.json` version이 1.2.0인지 확인
- [ ] `marketplace.json` version이 1.8.0이고 apple-craft 항목이 1.2.0인지 확인

https://claude.ai/code/session_01UbM5fBvjXNhd8BcBuMLDAz