### PR TITLE
refactor(apple-craft): review 모드를 독립 스킬 apple-review로 분리

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "oozoofrog-plugins",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "oozoofrog의 개인 Claude Code 플러그인 마켓플레이스 — macOS 릴리스 자동화, 컨텍스트 아키텍처, GPT 리서치, Codex CLI 위임, Apple 앱 자동화, Apple 플랫폼 통합 개발 어시스턴트, 플러그인 진단·수정",
   "owner": {
     "name": "oozoofrog",
@@ -61,7 +61,7 @@
     {
       "name": "apple-craft",
       "description": "Apple 플랫폼 통합 개발 어시스턴트 — Swift/SwiftUI/UIKit 코드 작성·코드 리뷰·디버깅 + Xcode MCP 연동 + Xcode 26 최신 API 참조 문서 20개 내장 + Apple 에코시스템 참조 문서 기반 코드 리뷰 + Plan→Design→Build→Evaluate 하네스 (V2, Pencil 디자인+다차원 평가+런타임 검증)",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "author": {
         "name": "oozoofrog"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Claude Code 플러그인 마켓플레이스 리포지토리.
 | gpt-research | gpt-research | — | — |
 | hey-codex | hey-codex | — | — |
 | app-automation | app-automation | — | — (.mcp.json: baepsae) |
-| apple-craft | apple-craft, apple-harness | harness-planner, harness-builder, harness-designer, harness-evaluator, harness-reviewer | — |
+| apple-craft | apple-craft, apple-harness, apple-review | harness-planner, harness-builder, harness-designer, harness-evaluator, harness-reviewer | — |
 | plugin-doctor | fixer | — | — |
 
 ## 플러그인 개발 규칙

--- a/plugins/apple-craft/.claude-plugin/plugin.json
+++ b/plugins/apple-craft/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "apple-craft",
   "description": "Apple 플랫폼 통합 개발 어시스턴트 — Swift/SwiftUI/UIKit 코드 작성·리뷰·디버깅 + Xcode MCP 연동 + Xcode 26 최신 API 참조 문서 20개 내장 + Pencil 디자인 통합",
   "author": { "name": "oozoofrog" },
-  "version": "1.9.0"
+  "version": "1.9.1"
 }

--- a/plugins/apple-craft/README.md
+++ b/plugins/apple-craft/README.md
@@ -40,9 +40,9 @@ Xcode 26 번들 문서 기반 최신 API 참조 문서 20개 내장.
 - "Liquid Glass 적용 방법 알려줘" → explore 모드 + 참조 문서 로드
 - "FoundationModels로 세션 만드는 코드" → implement 모드 + 참조 문서 로드
 
-### 코드 리뷰
-- "이 코드 리뷰해줘" → review 모드
-- "PR #42 리뷰 부탁해" → review 모드
+### 코드 리뷰 (`/apple-review`)
+- "이 코드 리뷰해줘" → `/apple-review` 스킬
+- "PR #42 리뷰 부탁해" → `/apple-review` 스킬
 
 ### 장기 개발 작업 (Harness 모드)
 - "처음부터 Liquid Glass 설정 화면 만들어줘" → harness 모드

--- a/plugins/apple-craft/agents/harness-reviewer.md
+++ b/plugins/apple-craft/agents/harness-reviewer.md
@@ -4,8 +4,8 @@ description: "apple-craft review 모드 전용 — Apple 에코시스템 참조 
 model: sonnet
 color: orange
 whenToUse: |
-  이 에이전트는 apple-craft 스킬의 review 모드(Phase R1)에서 호출됩니다.
-  직접 호출하지 마세요. apple-craft 스킬이 오케스트레이션합니다.
+  이 에이전트는 apple-review 스킬의 Phase R1(SCAN + CLASSIFY + ACT)에서 호출됩니다.
+  직접 호출하지 마세요. apple-review 스킬이 오케스트레이션합니다.
 tools:
   - Read
   - Write

--- a/plugins/apple-craft/skills/apple-craft/SKILL.md
+++ b/plugins/apple-craft/skills/apple-craft/SKILL.md
@@ -21,9 +21,6 @@ allowed-tools:
   - mcp__xcode__XcodeUpdate
   - mcp__xcode__XcodeGrep
   - mcp__xcode__XcodeGlob
-  - Agent
-  - mcp__plugin_github_github__issue_write
-  - mcp__plugin_github_github__search_issues
 ---
 
 <example>
@@ -100,7 +97,7 @@ Xcode 26 참조 문서(20개 주제) 내장으로 최신 API도 정확하게 지
 | **implement** | 만들어, 작성, 적용, 구현, 추가, 코드, 리팩토링, 마이그레이션, build, create, add, apply, refactor | 코드 작성 + 빌드 검증. 참조 문서 매칭 시 최신 API 활용 |
 | **explore** | 알려줘, 설명, 뭐가 바뀌었어, 차이, 어떻게, 비교, 추천, what, how, explain, diff, compare | API/코드 설명 + 코드 예시. `DocumentationSearch`로 공식 문서 검색 |
 | **troubleshoot** | 에러, 오류, 안돼, 크래시, 빌드 실패, 느려, 성능, 메모리, error, crash, fix, debug, slow | 빌드 로그/코드 분석 + 수정. `GetBuildLog`, `XcodeListNavigatorIssues` 활용 |
-| **review** | 리뷰, 코드 리뷰, review, 검토, 점검, PR 리뷰, audit, 봐줘, 확인해, 체크, 살펴, 분석, check, analyze, inspect | Apple 에코시스템 참조 문서 기반 코드 리뷰 + 자동 수정/이슈 생성 |
+| **review** | 리뷰, 코드 리뷰, review, 검토, 점검, PR 리뷰, audit, 봐줘, 확인해, 체크, 살펴, 분석, check, analyze, inspect | → `apple-review` 스킬로 전환 |
 | **harness** | 처음부터, 전체, 기능 개발, 대규모, 전면 리팩토링, harness | → `apple-craft-harness` 스킬로 전환 |
 
 **자동 선택**: 키워드가 불명확하면 사용자 의도를 추론합니다. 코드 파일이 언급되면 implement, 질문형이면 explore, 에러 메시지가 포함되면 troubleshoot, 기존 코드에 대한 평가/의견 요청이면 review.
@@ -259,66 +256,6 @@ Apple 프레임워크 API 설명, 변경 사항 비교, 사용법 안내를 할 
 3. 에러 해소 및 추가 경고 없는지 확인
 
 응답 형식은 `references/response-templates.md`를 참조하세요.
-
----
-
-## Mode: review
-
-Apple 에코시스템 참조 문서 기반의 심층 코드 리뷰를 수행합니다.
-일반 코드 리뷰와 달리, 20개 Apple API 참조 문서 + common-mistakes.md를 기준으로
-Apple 플랫폼 고유의 문제를 발견하고 트리아지합니다.
-
-### Phase R0: 리뷰 범위 결정
-
-1. AskUserQuestion으로 리뷰 대상 확인:
-   - "현재 브랜치의 변경사항 (git diff)"
-   - "특정 파일/디렉토리"
-   - "PR #N"
-2. 선택적: 리뷰 초점 확인 (전체 / Apple 에코시스템 / 보안 / 성능 / 스타일)
-3. 대상 파일 목록 수집:
-   - git diff: `git diff --name-only <base>..HEAD -- '*.swift'`
-   - PR: `gh pr diff <N> --name-only`
-   - 디렉토리: `Glob: pattern="**/*.swift" path=<경로>`
-
-### Phase R1: 스캔 + 분류 + 수정
-
-harness-reviewer 에이전트를 디스패치합니다:
-
-```
-Agent: harness-reviewer
-  - 리뷰 대상 파일 목록
-  - 리뷰 초점
-```
-
-에이전트가 수행하는 작업:
-- common-mistakes.md + code-style.md + 매칭된 참조 문서 기반 정적 분석
-- severity(critical/major/minor/suggestion) × complexity(simple-fix/needs-investigation/complex) 분류
-- critical/major + simple-fix 항목 자동 수정 + git commit
-- needs-investigation 항목 심층 분석
-- `.claude/review/review-findings.json` + `.claude/review/review-report.md` 출력
-
-### Phase R2: 트리아지
-
-review-findings.json을 읽고 action별 처리:
-
-1. **action=fixed**: 이미 수정 완료 → 보고만 (커밋 해시 포함)
-2. **action=issue**: AskUserQuestion으로 GitHub Issue 생성 여부 확인
-   - 승인 시 `mcp__plugin_github_github__issue_write` 사용
-   - Title: `[apple-craft review] {description}`
-   - Body: 발견 사항, 참조 문서 출처, 수정 방향 포함
-   - Labels: `apple-craft-review` + severity 라벨
-3. **action=user-decision**: AskUserQuestion으로 사용자 판단 요청
-   - minor + simple-fix 항목을 일괄 제시: "다음 N건을 자동 수정할까요?"
-   - 승인 시 Edit으로 수정 + git commit
-4. **action=report-only**: 보고만 (suggestions)
-
-### Phase R3: 최종 보고
-
-review-report.md를 기반으로 사용자에게 요약 출력:
-- severity별 건수 + 조치 현황 (수정됨/이슈 생성됨/보고만)
-- 자동 수정된 커밋 목록
-- 생성된 GitHub Issue 링크 목록
-- 잔여 suggestions 요약
 
 ---
 

--- a/plugins/apple-craft/skills/apple-review/SKILL.md
+++ b/plugins/apple-craft/skills/apple-review/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: apple-review
+description: apple-craft 리뷰 모드 — Apple 에코시스템 참조 문서 20개 + common-mistakes.md + code-style.md 기반 코드 리뷰 + 자동 수정 + GitHub Issue 생성. "리뷰", "코드 리뷰", "review", "검토", "점검", "PR 리뷰", "audit", "봐줘", "확인해", "체크", "살펴", "분석", "check", "analyze", "inspect", "코드 봐줘", "PR 확인", "코드 점검" 요청 시 활성화
+argument-hint: "[file, directory, or PR number]"
+allowed-tools:
+  - Agent
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - mcp__xcode__DocumentationSearch
+  - mcp__xcode__BuildProject
+  - mcp__xcode__GetBuildLog
+  - mcp__xcode__XcodeRefreshCodeIssuesInFile
+  - mcp__xcode__XcodeListNavigatorIssues
+  - mcp__xcode__ExecuteSnippet
+  - mcp__xcode__XcodeRead
+  - mcp__xcode__XcodeGrep
+  - mcp__xcode__XcodeGlob
+  - mcp__plugin_github_github__issue_write
+  - mcp__plugin_github_github__search_issues
+---
+
+<example>
+user: "이 코드 리뷰해줘"
+assistant: "review 모드로 Apple 에코시스템 참조 문서 기반 코드 리뷰를 수행합니다. 리뷰 범위를 확인하겠습니다."
+</example>
+
+<example>
+user: "PR #42 리뷰 부탁해"
+assistant: "review 모드로 PR #42의 변경 파일을 분석합니다. common-mistakes.md와 관련 참조 문서를 기준으로 Apple 플랫폼 관점에서 리뷰합니다."
+</example>
+
+<example>
+user: "SettingsView.swift 코드 점검"
+assistant: "review 모드로 해당 파일을 분석합니다. Liquid Glass, FoundationModels 등 사용 중인 프레임워크의 참조 문서를 기준으로 검토합니다."
+</example>
+
+<example>
+user: "이 프로젝트 전체 코드 봐줘"
+assistant: "review 모드로 프로젝트의 Swift 파일을 전체 스캔합니다. Apple 에코시스템 참조 문서 기반으로 심층 리뷰를 진행합니다."
+</example>
+
+# apple-review
+
+Apple 에코시스템 참조 문서 기반의 심층 코드 리뷰를 수행합니다.
+일반 코드 리뷰와 달리, 20개 Apple API 참조 문서 + common-mistakes.md를 기준으로
+Apple 플랫폼 고유의 문제를 발견하고 트리아지합니다.
+
+## Knowledge Authority
+
+참조 문서는 `${CLAUDE_PLUGIN_ROOT}/skills/apple-craft/references/`에 위치합니다.
+apple-craft 스킬과 동일한 참조 문서를 공유합니다.
+
+- `references/common-mistakes.md` — 필수 로드 (안티패턴 체크리스트)
+- `references/code-style.md` — 필수 로드 (Apple 코딩 컨벤션)
+- 나머지 18개 참조 문서 — 대상 코드의 프레임워크에 따라 선택 로드
+
+---
+
+## Phase R0: 리뷰 범위 결정
+
+1. AskUserQuestion으로 리뷰 대상 확인:
+   - "현재 브랜치의 변경사항 (git diff)"
+   - "특정 파일/디렉토리"
+   - "PR #N"
+2. 선택적: 리뷰 초점 확인 (전체 / Apple 에코시스템 / 보안 / 성능 / 스타일)
+3. 대상 파일 목록 수집:
+   - git diff: `git diff --name-only <base>..HEAD -- '*.swift'`
+   - PR: `gh pr diff <N> --name-only`
+   - 디렉토리: `Glob: pattern="**/*.swift" path=<경로>`
+
+---
+
+## Phase R1: 스캔 + 분류 + 수정
+
+harness-reviewer 에이전트를 디스패치합니다:
+
+```
+Agent: harness-reviewer
+  - 리뷰 대상 파일 목록
+  - 리뷰 초점
+```
+
+에이전트가 수행하는 작업:
+- common-mistakes.md + code-style.md + 매칭된 참조 문서 기반 정적 분석
+- severity(critical/major/minor/suggestion) × complexity(simple-fix/needs-investigation/complex) 분류
+- critical/major + simple-fix 항목 자동 수정 + git commit
+- needs-investigation 항목 심층 분석
+- `.claude/review/review-findings.json` + `.claude/review/review-report.md` 출력
+
+---
+
+## Phase R2: 트리아지
+
+review-findings.json을 읽고 action별 처리:
+
+1. **action=fixed**: 이미 수정 완료 → 보고만 (커밋 해시 포함)
+2. **action=issue**: AskUserQuestion으로 GitHub Issue 생성 여부 확인
+   - 승인 시 `mcp__plugin_github_github__issue_write` 사용
+   - Title: `[apple-craft review] {description}`
+   - Body: 발견 사항, 참조 문서 출처, 수정 방향 포함
+   - Labels: `apple-craft-review` + severity 라벨
+3. **action=user-decision**: AskUserQuestion으로 사용자 판단 요청
+   - minor + simple-fix 항목을 일괄 제시: "다음 N건을 자동 수정할까요?"
+   - 승인 시 Edit으로 수정 + git commit
+4. **action=report-only**: 보고만 (suggestions)
+
+---
+
+## Phase R3: 최종 보고
+
+review-report.md를 기반으로 사용자에게 요약 출력:
+- severity별 건수 + 조치 현황 (수정됨/이슈 생성됨/보고만)
+- 자동 수정된 커밋 목록
+- 생성된 GitHub Issue 링크 목록
+- 잔여 suggestions 요약
+
+---
+
+## Rules
+
+- 한국어로 응답하되, 코드와 API명은 원문 유지
+- 참조 문서 인용 시 **출처 파일명 + 섹션명** 반드시 명시
+- 프로젝트 컨벤션이 있으면 (CLAUDE.md, .swiftlint.yml 등) 해당 컨벤션 존중
+- Xcode MCP 미연결 시에도 코드 분석 기반 리뷰는 완전히 수행
+- GitHub MCP 미연결 시 complex 항목은 review-report.md에만 기록 (이슈 생성 생략)


### PR DESCRIPTION
## Summary
- Plugin Doctor 대칭성 조사에서 발견된 3건의 아키텍처 비대칭 수정
- review 모드를 독립 스킬 `apple-review`로 분리하여 harness/review 구조 통일
- `/apple-review`로 직접 호출 가능

## 대칭성 수정 결과

| 축 | Before | After |
|----|--------|-------|
| 스킬-CLI | harness만 독립, review는 내부 모드 | 둘 다 독립 스킬 |
| 에이전트 소속 | reviewer만 apple-craft 소속 | reviewer → apple-review 소속 |
| 네이밍 | reviewer의 소속 불일치 | whenToUse에 apple-review 명시 |

## Test plan
- [ ] `/apple-review`로 독립 스킬 호출 가능 확인
- [ ] `/apple-craft 리뷰해줘`가 apple-review 전환 안내
- [ ] harness-reviewer의 whenToUse가 apple-review 소속
- [ ] `/fixer` 플러그인 구조 검증

Closes #20