### PR TITLE
feat(apple-harness): Phase 3에 Collaborative Build 스타일 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "oozoofrog-plugins",
-  "version": "1.35.3",
+  "version": "1.36.0",
   "description": "oozoofrog의 개인 Claude Code 플러그인 마켓플레이스 — macOS 릴리스 자동화, 컨텍스트 아키텍처, GPT 리서치, Codex CLI 위임, Apple 앱 자동화, Apple 플랫폼 통합 개발 어시스턴트, 플러그인 진단·수정, Git 워크플로우 자동화, 릴리스 라이프사이클",
   "owner": {
     "name": "oozoofrog",
@@ -61,7 +61,7 @@
     {
       "name": "apple-craft",
       "description": "Apple 플랫폼 개발 스킬 모음 — 일반 구현/디버깅(apple-craft), 코드 리뷰(apple-review), 장기 대규모 구현 하네스(apple-harness), Pencil .pen → SwiftUI/UIKit 디자인 구현(pen-craft), App Store 배포 자동화(appstore-deploy), Xcode MCP 연동, xcodebuild+xcsift 빌드 폴백, 최신 Apple API 참조 문서 20개 내장",
-      "version": "1.15.2",
+      "version": "1.16.0",
       "author": {
         "name": "oozoofrog"
       },

--- a/plugins/apple-craft/.claude-plugin/plugin.json
+++ b/plugins/apple-craft/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "apple-craft",
   "description": "Apple 플랫폼 개발 스킬 모음 — 일반 구현/디버깅(apple-craft), 코드 리뷰(apple-review), 장기 대규모 구현 하네스(apple-harness, Designer 2-way split), App Store 배포 자동화(appstore-deploy), Xcode MCP 연동, xcodebuild+xcsift 빌드 폴백, 최신 Apple API 참조 문서 20개 내장, Pencil 디자인 통합",
   "author": { "name": "oozoofrog" },
-  "version": "1.15.2"
+  "version": "1.16.0"
 }

--- a/plugins/apple-craft/skills/apple-harness/SKILL.md
+++ b/plugins/apple-craft/skills/apple-harness/SKILL.md
@@ -250,14 +250,35 @@ mkdir -p {HARNESS_DIR}
 모든 에이전트 호출 시 프롬프트에 `HARNESS_DIR: {HARNESS_DIR}` 경로를 반드시 전달합니다.
 
 **재진입 감지 (새 대화에서 하네스 호출 시):**
-기존 HARNESS_DIR에 `session.json`이 존재하면, 이전 세션의 중단으로 판단합니다:
+
+**Step 1: 산출물 존재 확인**
+HARNESS_DIR에서 다음 파일을 확인합니다:
+- `session.json` 존재 → Step 2(session 기반 재진입)로 진행
+- `session.json` 없음 + `harness-spec.md`/`features.json` 존재 → Phase 1~2 중단. 사용자에게 "이전 Plan/Design 산출물이 있습니다. 이어서 진행할까요?" 확인 후, Phase 2.5(BUILD STYLE 선택)부터 재개
+- 아무 파일도 없음 → 새 세션 시작 (Phase 0)
+
+**Step 2: session.json 기반 재진입**
 1. `session.json`을 Read하여 `build_style`, `current_round`, `current_feature_id`, `phase`를 복구
 2. `features.json`을 Read하여 각 기능의 현재 status를 확인
 3. **session.json과 features.json을 cross-validation**하여 실제 재개 지점을 결정:
 
 ```
+# 0. 공통 보정: evaluate 단계에서 current_feature_id는 항상 null이어야 함
+if phase == "evaluate" && current_feature_id != null:
+    current_feature_id를 null로 보정
+
+# 1. current_round 보정: evaluation 보고서와 동기화
+if evaluation-round-{current_round}.md가 이미 존재:
+    current_round를 current_round+1로 보정
+    (이전 라운드 evaluate는 완료되었지만 다음 build 전이 전에 중단된 것)
+
+# 2. current_round 상한 검증
+if current_round > 4:
+    → 하네스 최대 라운드 초과. 현재 상태로 강제 종료, 결과 보고.
+
+# 3. phase별 재개 지점 결정
 if phase == "complete":
-    → 하네스 이미 완료. 완료 보고를 다시 보여주거나 새 하네스 시작.
+    → 하네스 이미 완료. "이전 세션이 완료되었습니다" 안내 후 완료 보고 재표시 또는 새 하네스 시작.
 
 if phase == "evaluate":
     features에 built 상태가 존재하는가?
@@ -752,28 +773,30 @@ failed → built (Builder 재구현)
   "build_style": "autonomous | collaborative",
   "current_round": 1,
   "current_feature_id": "F003 | null",
-  "phase": "plan | verify | design | build | evaluate | complete"
+  "phase": "build | evaluate | complete"
 }
 ```
 
 - `build_style`: Phase 2.5에서 설정, 모드 전환 시 업데이트
-- `current_round`: NEED_REVISION 판정 시 N+1로 증가 (Phase 4 진입이 아닌, 재빌드 결정 시점에 증가)
-- `current_feature_id`: collaborative 모드에서 기능 시작 시 설정, 완료/실패 시 null로 초기화. 재진입 시 이 값이 non-null이면 해당 기능이 중단된 것으로 판단
-- `phase`: 상태 전이 시 업데이트. 재진입 시 어느 Phase에서 재개할지 결정
+- `current_round`: 1에서 시작. NEED_REVISION 판정 시 N+1로 증가. **최대값: 4** (라운드 3 + 추가 1회). 재진입 시 `current_round > 4`이면 강제 종료.
+- `current_feature_id`: collaborative 모드에서 기능 시작 시 설정, 완료/실패 시 null로 초기화. autonomous 모드에서는 항상 null (Builder 서브에이전트가 관리하지 않음). 재진입 시 non-null이면 해당 기능이 중단된 것으로 판단.
+- `phase`: `build`, `evaluate`, `complete` 3개 값만 사용. Phase 0~2 단계에서는 session.json이 존재하지 않으므로 `plan`/`verify`/`design` 값은 사용하지 않음.
 
 **phase 상태 전이 다이어그램:**
 ```
-build_style 선택 → "build"
+build_style 선택 → "build" (current_round=1)
   │
   ▼
 Phase 3 완료 → "evaluate"
   │
   ├─ PASS → "complete" (최종)
   └─ NEED_REVISION → "build" (current_round +1, 재빌드 루프)
+                        │
+                        └─ current_round > 4 → 강제 종료
 ```
 
-**생성 시점:** Phase 2.5에서 build_style 선택 시 최초 생성. 이전 Phase(0~2)에서는 존재하지 않음.
-**업데이트 시점:** Phase 전환(build↔evaluate↔complete), 기능 시작/완료, 모드 전환 시.
+**생성 시점:** Phase 2.5에서 build_style 선택 시 최초 생성. 이전 Phase(0~2)에서는 존재하지 않음 — Phase 1~2 중단 시에는 harness-spec.md/features.json 존재 여부로 재진입 감지.
+**업데이트 시점:** Phase 전환(build↔evaluate↔complete), 기능 시작/완료, 모드 전환, NEED_REVISION 시 라운드 증가.
 
 ## Git Integration
 

--- a/plugins/apple-craft/skills/apple-harness/SKILL.md
+++ b/plugins/apple-craft/skills/apple-harness/SKILL.md
@@ -254,7 +254,27 @@ mkdir -p {HARNESS_DIR}
 **Step 1: 산출물 존재 확인**
 HARNESS_DIR에서 다음 파일을 확인합니다:
 - `session.json` 존재 → Step 2(session 기반 재진입)로 진행
-- `session.json` 없음 + `harness-spec.md`/`features.json` 존재 → Phase 1~2 중단. 사용자에게 "이전 Plan/Design 산출물이 있습니다. 이어서 진행할까요?" 확인 후, Phase 2.5(BUILD STYLE 선택)부터 재개
+- `session.json` 없음 + `features.json` 존재 → **features.json의 status를 분석하여 분류**:
+
+  ```
+  모든 기능이 pending인가?
+  ├─ 예 → Phase 1~2 중단 (Plan/Design 완료, Build 시작 전).
+  │   사용자에게 "이전 Plan/Design 산출물이 있습니다. 이어서 진행할까요?"
+  │   확인 후 Phase 2.5(BUILD STYLE 선택)부터 재개.
+  │
+  └─ 아니오 (built/verified/failed/partial 존재):
+      모든 기능이 verified인가?
+      ├─ 예 → 성공 완료 세션 (session.json 유실).
+      │   "이전 하네스가 성공적으로 완료된 상태입니다" 안내.
+      │   완료 보고 또는 새 하네스 시작 선택.
+      │
+      └─ 아니오 → 중간 세션 중단 (session.json 유실).
+          사용자에게 features.json 현재 상태를 요약하고,
+          build_style을 AskUserQuestion으로 선택한 뒤
+          Phase 3에서 pending/failed 기능부터 재개.
+  ```
+
+- `session.json` 없음 + `harness-spec.md`만 존재 (features.json 없음) → Phase 1 Planner 중간 중단. harness-spec.md를 확인하고 Phase 1부터 재개.
 - 아무 파일도 없음 → 새 세션 시작 (Phase 0)
 
 **Step 2: session.json 기반 재진입**

--- a/plugins/apple-craft/skills/apple-harness/SKILL.md
+++ b/plugins/apple-craft/skills/apple-harness/SKILL.md
@@ -245,8 +245,19 @@ mkdir -p {HARNESS_DIR}
 - `{HARNESS_DIR}/features.json`
 - `{HARNESS_DIR}/design-spec.md`
 - `{HARNESS_DIR}/evaluation-round-{N}.md`
+- `{HARNESS_DIR}/session.json` — 세션 메타데이터 (build_style, 현재 라운드 등)
 
 모든 에이전트 호출 시 프롬프트에 `HARNESS_DIR: {HARNESS_DIR}` 경로를 반드시 전달합니다.
+
+**재진입 감지 (새 대화에서 하네스 호출 시):**
+기존 HARNESS_DIR에 `session.json`이 존재하면, 이전 세션의 중단으로 판단합니다:
+1. `session.json`을 Read하여 `build_style`, `current_round`, `current_feature_id`, `phase`를 복구
+2. `features.json`을 Read하여 각 기능의 현재 status를 확인
+3. 사용자에게 현재 상태를 요약하고, 재개할 Phase를 안내:
+   - `phase = "build"` + 미완료 기능 존재 → Phase 3에서 재개 (build_style 유지)
+   - `phase = "evaluate"` → Phase 4에서 재개
+   - `current_feature_id`가 설정되어 있으면 → 해당 기능이 `pending` 상태이므로 그 기능부터 재시작
+4. 사용자가 다른 Phase부터 시작하고 싶으면 허용
 
 ### Phase 1: PLAN
 
@@ -414,7 +425,18 @@ AskUserQuestion:
       description: "기능별로 구현 계획을 확인하고, 기술적 선택에 함께 참여합니다. 느리지만 세부 설계를 직접 결정합니다."
 ```
 
-선택 결과를 `build_style` 변수에 저장하여 Phase 3에서 분기합니다.
+선택 결과를 `{HARNESS_DIR}/session.json`에 기록합니다:
+
+```json
+{
+  "build_style": "autonomous" | "collaborative",
+  "current_round": 1,
+  "current_feature_id": null,
+  "phase": "build"
+}
+```
+
+이 파일은 세션 중단/재진입 시 상태 복구에 사용됩니다.
 
 ### Phase 3: BUILD
 
@@ -466,7 +488,13 @@ BUILD_TOOL 탐지: Xcode MCP → xcodebuild+xcsift → swift build+xcsift → st
 ```
 for each feature (priority 순서):
 
-  ┌─ Step 1: 기능 카드 ─────────────────────────┐
+  ┌─ Step 1: 기능 시작 기록 ─────────────────────┐
+  │ session.json의 current_feature_id를 업데이트  │
+  │ → 중단 시 어느 기능에서 멈췄는지 복구 가능    │
+  └──────────────────────────────────────────────┘
+       │
+       ▼
+  ┌─ Step 2: 기능 카드 ─────────────────────────┐
   │ 기능 정보를 카드 형식으로 표시                │
   │                                              │
   │ ## 🎯 [F001] 앱 구조 설정                    │
@@ -477,14 +505,14 @@ for each feature (priority 순서):
   └──────────────────────────────────────────────┘
        │
        ▼
-  ┌─ Step 2: 구현 계획 ─────────────────────────┐
+  ┌─ Step 3: 구현 계획 ─────────────────────────┐
   │ • 생성/수정할 파일 목록과 각 파일의 역할      │
   │ • 사용할 패턴/프레임워크                      │
   │ • design-spec.md의 토큰 매핑 참조            │
   └──────────────────────────────────────────────┘
        │
        ▼
-  ┌─ Step 3: 기술적 선택지 (해당 시) ────────────┐
+  ┌─ Step 4: 기술적 선택지 (해당 시) ────────────┐
   │ 트레이드오프가 존재하는 결정에만 제시          │
   │ "명백한 최선"이 있으면 Claude가 결정          │
   │                                              │
@@ -497,28 +525,36 @@ for each feature (priority 순서):
   └──────────────────────────────────────────────┘
        │
        ▼
-  ┌─ Step 4: 외부 편집 감지 ─────────────────────┐
+  ┌─ Step 5: 외부 편집 감지 ─────────────────────┐
   │ git diff로 사용자의 외부 편집을 확인          │
   │ 변경이 있으면 인지하고 이후 코드에 반영       │
   └──────────────────────────────────────────────┘
        │
        ▼
-  ┌─ Step 5: 코드 작성 ─────────────────────────┐
+  ┌─ Step 6: 코드 작성 ─────────────────────────┐
   │ 합의된 계획에 따라 Write/Edit 도구로 구현     │
   │ design-spec.md의 토큰 매핑 참조              │
   │ category="ui" 시 뷰 연결 검증               │
   └──────────────────────────────────────────────┘
        │
        ▼
-  ┌─ Step 6: 빌드 검증 + 커밋 ──────────────────┐
+  ┌─ Step 7: 빌드 검증 + 상태 기록 + 커밋 ──────┐
   │ BUILD_TOOL로 빌드 검증 (폴백 체인 동일)       │
   │ 실패 시 사용자와 함께 에러 분석/수정 (최대 3회)│
-  │ features.json status → built                 │
-  │ git commit: "feat(F001): <설명>"             │
+  │                                              │
+  │ ✅ 빌드 성공 시 (이 순서대로 실행):           │
+  │   1. features.json status → built            │
+  │   2. git commit: "feat(F001): <설명>"        │
+  │   3. session.json current_feature_id → null  │
+  │                                              │
+  │ ❌ 빌드 3회 실패 시:                          │
+  │   1. features.json status → failed           │
+  │   2. session.json current_feature_id → null  │
+  │   3. 사용자에게 스킵/재시도 선택 제시         │
   └──────────────────────────────────────────────┘
        │
        ▼
-  ┌─ Step 7: 진행 상황 표시 ─────────────────────┐
+  ┌─ Step 8: 진행 상황 표시 ─────────────────────┐
   │ | ID   | 기능        | 상태      |           │
   │ |------|------------|----------|            │
   │ | F001 | 앱 구조    | ✅ 완료   |           │
@@ -527,9 +563,11 @@ for each feature (priority 순서):
   └──────────────────────────────────────────────┘
        │
        ▼
-  ┌─ Step 8: 모드 전환 체크 ─────────────────────┐
+  ┌─ Step 9: 모드 전환 체크 ─────────────────────┐
   │ 사용자가 "나머지는 자율로" → autonomous 전환  │
   │ 남은 기능이 7개 이상 → 자율 전환 제안         │
+  │                                              │
+  │ 전환 시 session.json build_style 업데이트     │
   └──────────────────────────────────────────────┘
 ```
 
@@ -538,8 +576,8 @@ for each feature (priority 순서):
 - 사용자 요청 시 **병렬 작업** 가능 (사용자: A 파일, Claude: B 파일).
 
 **모드 전환 (양방향):**
-- collaborative → autonomous: 사용자 요청 또는 남은 기능이 많을 때 제안. 남은 기능을 harness-builder 서브에이전트에 위임.
-- autonomous → collaborative: Evaluator 피드백 후 사용자가 함께 수정하고 싶을 때 전환 가능.
+- collaborative → autonomous: 사용자 요청 또는 남은 기능이 많을 때 제안. 남은 기능을 harness-builder 서브에이전트에 위임. `session.json`의 `build_style`을 `"autonomous"`로 업데이트.
+- autonomous → collaborative: Evaluator 피드백 후 사용자가 함께 수정하고 싶을 때 전환 가능. `session.json`의 `build_style`을 `"collaborative"`로 업데이트.
 
 **컨텍스트 관리:**
 - 메인 대화에서 실행되므로 컨텍스트 누적에 주의.
@@ -547,6 +585,11 @@ for each feature (priority 순서):
 - features.json의 진행 상태가 파일에 기록되므로, compaction 발생 시에도 현재 상태 복구 가능.
 
 ### Phase 4: EVALUATE
+
+**Phase 4 진입 시 session.json 업데이트:**
+```json
+{ "phase": "evaluate", "current_round": N, "current_feature_id": null }
+```
 
 harness-evaluator 에이전트를 호출합니다:
 
@@ -678,6 +721,25 @@ failed → built (Builder 재구현)
 - status와 priority만 업데이트 가능
 - JSON 형식 유지 (마크다운이 아닌 JSON — 모델의 부적절한 편집 방지)
 
+## session.json Schema
+
+```json
+{
+  "build_style": "autonomous | collaborative",
+  "current_round": 1,
+  "current_feature_id": "F003 | null",
+  "phase": "plan | verify | design | build | evaluate | complete"
+}
+```
+
+- `build_style`: Phase 2.5에서 설정, 모드 전환 시 업데이트
+- `current_round`: Phase 4 진입 시 증가
+- `current_feature_id`: collaborative 모드에서 기능 시작 시 설정, 완료/실패 시 null로 초기화. 재진입 시 이 값이 non-null이면 해당 기능이 중단된 것으로 판단
+- `phase`: 각 Phase 진입 시 업데이트. 재진입 시 어느 Phase에서 재개할지 결정
+
+**생성 시점:** Phase 2.5에서 build_style 선택 시 최초 생성. 이전 Phase(0~2)에서는 존재하지 않음.
+**업데이트 시점:** Phase 전환, 기능 시작/완료, 모드 전환, 라운드 증가 시.
+
 ## Git Integration
 
 - Builder가 각 기능 완료 시 **설명적 커밋 메시지**로 커밋
@@ -752,9 +814,9 @@ Phase 1: PLAN 시작 — Planner 에이전트가 스펙을 작성합니다...
 
 5. **자기평가 한계**: Evaluator도 LLM이므로 완벽한 QA는 아닙니다. 최종 결과는 반드시 사람이 검토해야 합니다.
 
-7. **Collaborative 모드 컨텍스트**: Collaborative 모드는 메인 대화에서 실행되므로, 기능 수가 많은 프로젝트에서는 컨텍스트 윈도우가 빠르게 소모됩니다. 10개 이상의 기능이 있는 프로젝트에서는 autonomous 모드를 권장하거나, collaborative로 핵심 기능만 진행한 후 나머지를 autonomous로 전환하세요.
-
 6. **Pencil MCP 선택적**: Phase 2-A(디자인 설계)는 Pencil 없이도 항상 실행되어 Builder/Evaluator에게 토큰 매핑과 화면 구조를 제공합니다. Phase 2-B(디자인 구현)만 Pencil MCP 연결 시 실행됩니다. Pencil이 SwiftUI 코드를 직접 생성하지 않으므로, 디자인→코드 변환은 Builder가 수행합니다.
+
+7. **Collaborative 모드 컨텍스트**: Collaborative 모드는 메인 대화에서 실행되므로, 기능 수가 많은 프로젝트에서는 컨텍스트 윈도우가 빠르게 소모됩니다. 10개 이상의 기능이 있는 프로젝트에서는 autonomous 모드를 권장하거나, collaborative로 핵심 기능만 진행한 후 나머지를 autonomous로 전환하세요.
 
 ## Quick Reference
 
@@ -781,8 +843,8 @@ apple-harness 실행 흐름
 │   ├─ 기존 .pen 읽기 또는 새 디자인 생성 + design-spec.md pending backfill
 │   └─ Phase 3으로 진행
 ├─ Phase 2.5: BUILD STYLE 선택 (AskUserQuestion)
-│   ├─ autonomous: 서브에이전트 자율 구현 (기존)
-│   └─ collaborative: 메인 대화에서 사용자와 협업 구현
+│   ├─ autonomous | collaborative 선택
+│   └─ {HARNESS_DIR}/session.json 생성 (build_style, phase, round 기록)
 ├─ Phase 3: BUILD
 │   ├─ [autonomous] harness-builder 서브에이전트 호출
 │   │   ├─ Step 0: 빌드 도구 탐지
@@ -793,15 +855,18 @@ apple-harness 실행 흐름
 │       ├─ 기능별: 카드 표시 → 구현 계획 → 기술적 선택지 → 코드 작성 → 빌드 → 커밋
 │       ├─ 외부 편집 감지 (git diff)
 │       ├─ 모드 전환 가능 (collaborative ↔ autonomous)
+│       ├─ session.json에 current_feature_id 기록 (재진입 대비)
 │       └─ features.json status → built
 ├─ Phase 4: EVALUATE (harness-evaluator)
+│   ├─ session.json phase → "evaluate" 업데이트
 │   ├─ Step 0: baepsae/axe 최우선 탐지 + Pencil + 보조 도구 탐색
 │   ├─ 4축 다차원 검증 (기능완성/코드품질/UI품질/인터랙션)
 │   ├─ 디자인-코드 비교 ({HARNESS_DIR}/design-spec.md 존재 시)
 │   ├─ {HARNESS_DIR}/evaluation-round-{N}.md 상세 로그 생성
 │   ├─ PASS/PARTIAL/FAIL 점수 + 가중 평균
-│   └─ 80% 통과 → 완료 / 미달 → BUILD 자동 재실행
-└─ 자율 루프 (최대 3 라운드), 3회 실패 시에만 사용자 확인
+│   └─ 80% 통과 → 완료 / 미달 → BUILD 재실행 (build_style 유지)
+├─ 자율 루프 (최대 3 라운드), 3회 실패 시에만 사용자 확인
+└─ 재진입: session.json 존재 시 → 상태 복구 후 해당 Phase에서 재개
 ```
 
 ## Walkthrough Example

--- a/plugins/apple-craft/skills/apple-harness/SKILL.md
+++ b/plugins/apple-craft/skills/apple-harness/SKILL.md
@@ -253,11 +253,30 @@ mkdir -p {HARNESS_DIR}
 기존 HARNESS_DIR에 `session.json`이 존재하면, 이전 세션의 중단으로 판단합니다:
 1. `session.json`을 Read하여 `build_style`, `current_round`, `current_feature_id`, `phase`를 복구
 2. `features.json`을 Read하여 각 기능의 현재 status를 확인
-3. 사용자에게 현재 상태를 요약하고, 재개할 Phase를 안내:
-   - `phase = "build"` + 미완료 기능 존재 → Phase 3에서 재개 (build_style 유지)
-   - `phase = "evaluate"` → Phase 4에서 재개
-   - `current_feature_id`가 설정되어 있으면 → 해당 기능이 `pending` 상태이므로 그 기능부터 재시작
-4. 사용자가 다른 Phase부터 시작하고 싶으면 허용
+3. **session.json과 features.json을 cross-validation**하여 실제 재개 지점을 결정:
+
+```
+if phase == "complete":
+    → 하네스 이미 완료. 완료 보고를 다시 보여주거나 새 하네스 시작.
+
+if phase == "evaluate":
+    features에 built 상태가 존재하는가?
+    ├─ 예 → Phase 4(EVALUATE)에서 재개 (아직 평가되지 않은 built 기능이 있음)
+    └─ 아니오 (모두 verified/failed/partial):
+        failed/partial이 존재하는가?
+        ├─ 예 → phase를 "build"로 보정, Phase 3에서 재개 (NEED_REVISION 후 중단된 것)
+        └─ 아니오 (모두 verified) → phase를 "complete"로 보정, 완료 보고
+
+if phase == "build":
+    current_feature_id가 non-null인가?
+    ├─ 예 → 해당 기능의 features.json status 확인:
+    │   ├─ pending → 해당 기능부터 재시작 (구현 중 중단)
+    │   └─ built → current_feature_id를 null로 보정, 다음 pending/failed 기능으로 이동
+    └─ 아니오 → 다음 pending/failed 기능부터 재개
+```
+
+4. 사용자에게 현재 상태를 요약하고, 재개할 Phase를 안내
+5. 사용자가 다른 Phase부터 시작하고 싶으면 허용
 
 ### Phase 1: PLAN
 
@@ -616,11 +635,16 @@ Agent 도구 호출:
     - 디자인 토큰이 SwiftUI 코드에 올바르게 반영되었는지 검증하세요
 ```
 
-**Phase 4 결과 처리:**
-- 판정 PASS (80%+ 기능 통과) → **하네스 완료**
-- 판정 NEED_REVISION:
-  - `build_style = "autonomous"` → Evaluator의 FAIL 피드백을 Builder에게 전달 → Phase 3-A 재실행
-  - `build_style = "collaborative"` → FAIL 항목을 사용자와 함께 분석하고 수정 → Phase 3-B로 FAIL/PARTIAL 기능만 재진행. 이 시점에서 사용자가 autonomous 전환을 요청할 수 있음.
+**Phase 4 결과 처리 + session.json 상태 전이:**
+
+- 판정 **PASS** (80%+ 기능 통과):
+  1. `session.json` → `{ "phase": "complete", "current_round": N }`
+  2. **하네스 완료** — 최종 보고 출력
+
+- 판정 **NEED_REVISION**:
+  1. `session.json` → `{ "phase": "build", "current_round": N+1 }` ← 즉시 build로 전이 + 라운드 증가
+  2. `build_style = "autonomous"` → Evaluator의 FAIL 피드백을 Builder에게 전달 → Phase 3-A 재실행
+  3. `build_style = "collaborative"` → FAIL 항목을 사용자와 함께 분석하고 수정 → Phase 3-B로 FAIL/PARTIAL 기능만 재진행. 이 시점에서 사용자가 autonomous 전환을 요청할 수 있음.
 
 ### Loop Control
 
@@ -733,12 +757,23 @@ failed → built (Builder 재구현)
 ```
 
 - `build_style`: Phase 2.5에서 설정, 모드 전환 시 업데이트
-- `current_round`: Phase 4 진입 시 증가
+- `current_round`: NEED_REVISION 판정 시 N+1로 증가 (Phase 4 진입이 아닌, 재빌드 결정 시점에 증가)
 - `current_feature_id`: collaborative 모드에서 기능 시작 시 설정, 완료/실패 시 null로 초기화. 재진입 시 이 값이 non-null이면 해당 기능이 중단된 것으로 판단
-- `phase`: 각 Phase 진입 시 업데이트. 재진입 시 어느 Phase에서 재개할지 결정
+- `phase`: 상태 전이 시 업데이트. 재진입 시 어느 Phase에서 재개할지 결정
+
+**phase 상태 전이 다이어그램:**
+```
+build_style 선택 → "build"
+  │
+  ▼
+Phase 3 완료 → "evaluate"
+  │
+  ├─ PASS → "complete" (최종)
+  └─ NEED_REVISION → "build" (current_round +1, 재빌드 루프)
+```
 
 **생성 시점:** Phase 2.5에서 build_style 선택 시 최초 생성. 이전 Phase(0~2)에서는 존재하지 않음.
-**업데이트 시점:** Phase 전환, 기능 시작/완료, 모드 전환, 라운드 증가 시.
+**업데이트 시점:** Phase 전환(build↔evaluate↔complete), 기능 시작/완료, 모드 전환 시.
 
 ## Git Integration
 

--- a/plugins/apple-craft/skills/apple-harness/SKILL.md
+++ b/plugins/apple-craft/skills/apple-harness/SKILL.md
@@ -66,7 +66,15 @@ Anthropic의 [Harness Design](https://www.anthropic.com/engineering/harness-desi
          │
          ▼
 ┌─────────────────────────────────┐
-│  Phase 3: BUILD                 │  harness-builder 에이전트
+│  Phase 2.5: BUILD STYLE 선택   │  AskUserQuestion
+│  autonomous | collaborative    │
+└────────┬────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────┐
+│  Phase 3: BUILD                 │
+│  ┌ autonomous: harness-builder  │  서브에이전트 자율 구현
+│  └ collaborative: 메인 대화     │  사용자와 기능별 협업 구현
 │  기능별 코드 작성 + 빌드        │  {HARNESS_DIR}/design-spec.md 참조 (있으면)
 │  기능별 git 커밋                │  ◄── EVALUATE 피드백 (자동)
 └────────┬────────────────────────┘
@@ -391,9 +399,30 @@ Agent 도구 호출:
 
 **Agent 실패 처리**: "디자인 구현 실패, architect 산출물만으로 진행합니다"로 보고하고 Phase 3 진행 (graceful degradation).
 
+### Phase 2.5: BUILD STYLE 선택
+
+Phase 2 완료 후, Phase 3 진입 전에 빌드 스타일을 선택합니다:
+
+```
+AskUserQuestion:
+  question: "Build 스타일을 선택해주세요"
+  header: "Phase 3"
+  options:
+    - label: "자율 모드 (Autonomous)"
+      description: "Builder 에이전트가 모든 기능을 자율적으로 구현합니다. 빠르지만 세부 결정에 참여할 수 없습니다."
+    - label: "협업 모드 (Collaborative)"
+      description: "기능별로 구현 계획을 확인하고, 기술적 선택에 함께 참여합니다. 느리지만 세부 설계를 직접 결정합니다."
+```
+
+선택 결과를 `build_style` 변수에 저장하여 Phase 3에서 분기합니다.
+
 ### Phase 3: BUILD
 
-harness-builder 에이전트를 호출합니다:
+`build_style`에 따라 분기합니다.
+
+#### Phase 3-A: Autonomous Build (build_style = "autonomous")
+
+기존과 동일하게 harness-builder 에이전트를 호출합니다:
 
 ```
 Agent 도구 호출:
@@ -412,13 +441,110 @@ Agent 도구 호출:
     .pen 파일의 화면 구조와 디자인 토큰을 SwiftUI 코드에 반영하세요.
 ```
 
-**Phase 3 완료 검증 (필수):**
+**Phase 3-A 완료 검증 (필수):**
 Builder 에이전트 완료 후:
 1. `{HARNESS_DIR}/features.json`을 Read하여 status 변경 확인
 2. pending/failed가 남아있으면 Builder가 일부만 완료한 것 → 사용자에게 보고
 3. `built_unverified` 상태가 있으면 Xcode MCP 미연결 경고 표시
 
 **Agent 실패 처리**: Builder가 중간에 실패하면, {HARNESS_DIR}/features.json의 현재 상태를 확인하여 완료된 기능과 미완료 기능을 사용자에게 보고합니다.
+
+#### Phase 3-B: Collaborative Build (build_style = "collaborative")
+
+서브에이전트를 호출하지 않고, **메인 대화에서 직접 실행**합니다.
+사용자와 기능별로 대화하며 구현합니다.
+
+**Step 0: 빌드 도구 탐지**
+Autonomous Build의 Builder와 동일한 폴백 체인으로 빌드 도구를 탐지합니다:
+```
+BUILD_TOOL 탐지: Xcode MCP → xcodebuild+xcsift → swift build+xcsift → static
+```
+
+**기능 루프:**
+`{HARNESS_DIR}/features.json`에서 `status=pending|failed|partial`인 기능을 priority 순서대로 하나씩 진행합니다:
+
+```
+for each feature (priority 순서):
+
+  ┌─ Step 1: 기능 카드 ─────────────────────────┐
+  │ 기능 정보를 카드 형식으로 표시                │
+  │                                              │
+  │ ## 🎯 [F001] 앱 구조 설정                    │
+  │ **설명**: 기본 App 구조와 NavigationStack     │
+  │ **검증**: 앱 실행 시 메인 화면 표시           │
+  │ **의존성**: 없음                              │
+  │ **디자인 토큰**: $bg, $accent (있으면)        │
+  └──────────────────────────────────────────────┘
+       │
+       ▼
+  ┌─ Step 2: 구현 계획 ─────────────────────────┐
+  │ • 생성/수정할 파일 목록과 각 파일의 역할      │
+  │ • 사용할 패턴/프레임워크                      │
+  │ • design-spec.md의 토큰 매핑 참조            │
+  └──────────────────────────────────────────────┘
+       │
+       ▼
+  ┌─ Step 3: 기술적 선택지 (해당 시) ────────────┐
+  │ 트레이드오프가 존재하는 결정에만 제시          │
+  │ "명백한 최선"이 있으면 Claude가 결정          │
+  │                                              │
+  │ 예: "NavigationStack vs NavigationSplitView?" │
+  │ - Option A: NavigationStack — iOS 16+, 단순  │
+  │ - Option B: NavigationSplitView — iPad 대응  │
+  │                                              │
+  │ 판단 기준: "두 선택지의 결과가 사용자에게      │
+  │ 체감 가능하게 다른가?" → 아니면 Claude 결정   │
+  └──────────────────────────────────────────────┘
+       │
+       ▼
+  ┌─ Step 4: 외부 편집 감지 ─────────────────────┐
+  │ git diff로 사용자의 외부 편집을 확인          │
+  │ 변경이 있으면 인지하고 이후 코드에 반영       │
+  └──────────────────────────────────────────────┘
+       │
+       ▼
+  ┌─ Step 5: 코드 작성 ─────────────────────────┐
+  │ 합의된 계획에 따라 Write/Edit 도구로 구현     │
+  │ design-spec.md의 토큰 매핑 참조              │
+  │ category="ui" 시 뷰 연결 검증               │
+  └──────────────────────────────────────────────┘
+       │
+       ▼
+  ┌─ Step 6: 빌드 검증 + 커밋 ──────────────────┐
+  │ BUILD_TOOL로 빌드 검증 (폴백 체인 동일)       │
+  │ 실패 시 사용자와 함께 에러 분석/수정 (최대 3회)│
+  │ features.json status → built                 │
+  │ git commit: "feat(F001): <설명>"             │
+  └──────────────────────────────────────────────┘
+       │
+       ▼
+  ┌─ Step 7: 진행 상황 표시 ─────────────────────┐
+  │ | ID   | 기능        | 상태      |           │
+  │ |------|------------|----------|            │
+  │ | F001 | 앱 구조    | ✅ 완료   |           │
+  │ | F002 | 설정 화면  | 🔧 진행중 |           │
+  │ | F003 | 데이터 모델 | ⏳ 대기   |           │
+  └──────────────────────────────────────────────┘
+       │
+       ▼
+  ┌─ Step 8: 모드 전환 체크 ─────────────────────┐
+  │ 사용자가 "나머지는 자율로" → autonomous 전환  │
+  │ 남은 기능이 7개 이상 → 자율 전환 제안         │
+  └──────────────────────────────────────────────┘
+```
+
+**사용자 역할 분담:**
+- 사용자가 "이 부분은 내가 직접 할게" → **대기 + 보조** (기본). 사용자가 완료하면 Read로 확인 후 리뷰/보완.
+- 사용자 요청 시 **병렬 작업** 가능 (사용자: A 파일, Claude: B 파일).
+
+**모드 전환 (양방향):**
+- collaborative → autonomous: 사용자 요청 또는 남은 기능이 많을 때 제안. 남은 기능을 harness-builder 서브에이전트에 위임.
+- autonomous → collaborative: Evaluator 피드백 후 사용자가 함께 수정하고 싶을 때 전환 가능.
+
+**컨텍스트 관리:**
+- 메인 대화에서 실행되므로 컨텍스트 누적에 주의.
+- 기능 완료마다 이전 기능의 구현 세부사항을 요약하고, 다음 기능에 필요한 인터페이스 정보만 유지.
+- features.json의 진행 상태가 파일에 기록되므로, compaction 발생 시에도 현재 상태 복구 가능.
 
 ### Phase 4: EVALUATE
 
@@ -449,25 +575,50 @@ Agent 도구 호출:
 
 **Phase 4 결과 처리:**
 - 판정 PASS (80%+ 기능 통과) → **하네스 완료**
-- 판정 NEED_REVISION → Evaluator의 FAIL 피드백을 Builder에게 전달 → Phase 3 재실행
+- 판정 NEED_REVISION:
+  - `build_style = "autonomous"` → Evaluator의 FAIL 피드백을 Builder에게 전달 → Phase 3-A 재실행
+  - `build_style = "collaborative"` → FAIL 항목을 사용자와 함께 분석하고 수정 → Phase 3-B로 FAIL/PARTIAL 기능만 재진행. 이 시점에서 사용자가 autonomous 전환을 요청할 수 있음.
 
-### Loop Control (자율 진행)
+### Loop Control
+
+#### Autonomous 모드 (자율 진행)
 
 ```
-라운드 1: BUILD → EVALUATE
+라운드 1: BUILD(3-A) → EVALUATE
   PASS → 완료, 사용자에게 최종 보고
   NEED_REVISION → 자동으로 라운드 2 진행 (중간 보고만)
 
-라운드 2: BUILD ({HARNESS_DIR}/evaluation-round-1.md 참조) → EVALUATE
+라운드 2: BUILD(3-A) ({HARNESS_DIR}/evaluation-round-1.md 참조) → EVALUATE
   PASS → 완료
   NEED_REVISION → 자동으로 라운드 3 진행
 
-라운드 3: BUILD ({HARNESS_DIR}/evaluation-round-2.md 참조) → EVALUATE
+라운드 3: BUILD(3-A) ({HARNESS_DIR}/evaluation-round-2.md 참조) → EVALUATE
   PASS → 완료
   NEED_REVISION → 사용자에게 상황 보고 + 선택:
     a) 계속 → 라운드 4 (최종, 추가 1회만 허용)
     b) 중단 → 현재 상태로 종료, {HARNESS_DIR}/features.json과 커밋 히스토리 보고
     c) 수동 수정 → 사용자가 직접 수정 후 Evaluate만 재실행
+```
+
+#### Collaborative 모드
+
+```
+라운드 1: BUILD(3-B, 사용자와 협업) → EVALUATE
+  PASS → 완료, 사용자에게 최종 보고
+  NEED_REVISION → FAIL 항목을 사용자와 함께 분석, 수정 방향 토론 후 재구현
+
+라운드 2: BUILD(3-B, FAIL/PARTIAL만) → EVALUATE
+  PASS → 완료
+  NEED_REVISION → 라운드 3 진행
+
+라운드 3: BUILD(3-B) → EVALUATE
+  PASS → 완료
+  NEED_REVISION → 사용자에게 상황 보고 + 선택:
+    a) 계속 (collaborative) → 라운드 4
+    b) 자율 전환 → 남은 FAIL 항목을 autonomous로 전환
+    c) 중단 → 현재 상태로 종료
+
+모드 전환: 어느 라운드에서든 사용자가 요청하면 autonomous ↔ collaborative 전환 가능
 ```
 
 Builder 재실행 시 프롬프트에 반드시 포함:
@@ -539,6 +690,7 @@ failed → built (Builder 재구현)
 - 각 에이전트는 **독립 서브에이전트**로 실행 → 자연스러운 컨텍스트 격리
 - 에이전트 간 통신은 **파일 기반** ({HARNESS_DIR}/harness-spec.md, {HARNESS_DIR}/features.json)
 - 대규모 프로젝트의 경우 Builder가 자동 컴팩션 활용
+- **Collaborative 모드 주의**: 메인 대화에서 실행되므로 컨텍스트 누적이 발생함. 기능 완료마다 이전 기능의 구현 세부사항을 요약하고, 다음 기능에 필요한 인터페이스 정보만 유지. 남은 기능이 7개 이상이면 autonomous 전환을 제안.
 
 ## Response Templates
 
@@ -547,7 +699,7 @@ failed → built (Builder 재구현)
 ## 🔨 apple-craft harness 시작
 
 **요청**: <사용자 요구사항>
-**모드**: Plan → Design → Build → Evaluate (최대 3 라운드)
+**모드**: Plan → Design → Build(<build_style>) → Evaluate (최대 3 라운드)
 
 Phase 1: PLAN 시작 — Planner 에이전트가 스펙을 작성합니다...
 ```
@@ -600,6 +752,8 @@ Phase 1: PLAN 시작 — Planner 에이전트가 스펙을 작성합니다...
 
 5. **자기평가 한계**: Evaluator도 LLM이므로 완벽한 QA는 아닙니다. 최종 결과는 반드시 사람이 검토해야 합니다.
 
+7. **Collaborative 모드 컨텍스트**: Collaborative 모드는 메인 대화에서 실행되므로, 기능 수가 많은 프로젝트에서는 컨텍스트 윈도우가 빠르게 소모됩니다. 10개 이상의 기능이 있는 프로젝트에서는 autonomous 모드를 권장하거나, collaborative로 핵심 기능만 진행한 후 나머지를 autonomous로 전환하세요.
+
 6. **Pencil MCP 선택적**: Phase 2-A(디자인 설계)는 Pencil 없이도 항상 실행되어 Builder/Evaluator에게 토큰 매핑과 화면 구조를 제공합니다. Phase 2-B(디자인 구현)만 Pencil MCP 연결 시 실행됩니다. Pencil이 SwiftUI 코드를 직접 생성하지 않으므로, 디자인→코드 변환은 Builder가 수행합니다.
 
 ## Quick Reference
@@ -626,14 +780,20 @@ apple-harness 실행 흐름
 │   ├─ AskUserQuestion으로 사용자 선택 확인
 │   ├─ 기존 .pen 읽기 또는 새 디자인 생성 + design-spec.md pending backfill
 │   └─ Phase 3으로 진행
-├─ Phase 3: BUILD (harness-builder)
-│   ├─ Step 0: 빌드 도구 탐지 (Xcode MCP → xcodebuild+xcsift → swift build+xcsift → static)
-│   ├─ {HARNESS_DIR}/features.json에서 pending/failed 기능 선택
-│   ├─ 참조 문서 Read
-│   ├─ Swift 코드 작성 ({HARNESS_DIR}/design-spec.md 참조)
-│   ├─ 빌드 검증 (BUILD_TOOL에 따른 폴백 체인, 내부 3회 재시도)
-│   ├─ {HARNESS_DIR}/features.json status → built (검증 성공) 또는 built_unverified (static)
-│   └─ git commit
+├─ Phase 2.5: BUILD STYLE 선택 (AskUserQuestion)
+│   ├─ autonomous: 서브에이전트 자율 구현 (기존)
+│   └─ collaborative: 메인 대화에서 사용자와 협업 구현
+├─ Phase 3: BUILD
+│   ├─ [autonomous] harness-builder 서브에이전트 호출
+│   │   ├─ Step 0: 빌드 도구 탐지
+│   │   ├─ pending/failed 기능 자율 구현 + 빌드 검증 + 커밋
+│   │   └─ features.json status → built
+│   └─ [collaborative] 메인 대화에서 직접 실행
+│       ├─ Step 0: 빌드 도구 탐지 (동일 폴백 체인)
+│       ├─ 기능별: 카드 표시 → 구현 계획 → 기술적 선택지 → 코드 작성 → 빌드 → 커밋
+│       ├─ 외부 편집 감지 (git diff)
+│       ├─ 모드 전환 가능 (collaborative ↔ autonomous)
+│       └─ features.json status → built
 ├─ Phase 4: EVALUATE (harness-evaluator)
 │   ├─ Step 0: baepsae/axe 최우선 탐지 + Pencil + 보조 도구 탐색
 │   ├─ 4축 다차원 검증 (기능완성/코드품질/UI품질/인터랙션)


### PR DESCRIPTION
## Summary

- apple-harness Phase 3에 `build_style: autonomous | collaborative` 분기를 추가
- Collaborative 모드: 서브에이전트 대신 메인 대화에서 사용자와 기능별 협업 구현
- `session.json` 상태 지속화 + cross-validation 재진입 로직으로 세션 중단/재개 지원
- 기존 Phase 0~2, Phase 4는 변경 없음, features.json 스키마 변경 없음

### 주요 변경
- **Phase 2.5**: AskUserQuestion으로 autonomous/collaborative 선택, session.json 생성
- **Phase 3-B**: 기능 카드 → 구현 계획 → 기술적 선택지 → 코드 작성 → 빌드 → 커밋 플로우
- **session.json**: build_style, current_round, current_feature_id, phase 추적
- **재진입 로직**: session.json ↔ features.json cross-validation으로 5가지 중단 시나리오 복구
- **모드 전환**: collaborative ↔ autonomous 양방향 전환

Closes #51

## Test plan

- [ ] apple-harness 시작 시 AskUserQuestion으로 모드 선택지가 표시되는지 확인
- [ ] collaborative 모드에서 기능 카드, 구현 계획, 진행 상황 표가 올바르게 출력되는지 확인
- [ ] 기능 완료 시 features.json status 업데이트 + session.json current_feature_id null 초기화 확인
- [ ] collaborative → autonomous 모드 전환 시 session.json build_style 업데이트 확인
- [ ] 세션 중단 후 재진입 시 cross-validation 보정이 올바르게 동작하는지 확인
- [ ] session.json 없이 features.json만 있을 때 성공 세션 vs pre-session 중단 올바르게 분류되는지 확인
- [ ] `/fixer`로 마켓플레이스 검증 통과 확인